### PR TITLE
Added if statement to use correct colour conversion name for opencv 4

### DIFF
--- a/src/recttools.hpp
+++ b/src/recttools.hpp
@@ -131,10 +131,10 @@ inline cv::Mat getGrayImage(cv::Mat img)
 {
     if (img.channels() == 3)
     {
-#if(CV_MAJOR_VERSION == 4)
-        cv::cvtColor(img, img, cv::COLOR_BGR2GRAY);
-#else
+#if(CV_MAJOR_VERSION < 4)
         cv::cvtColor(img, img, CV_BGR2GRAY);
+#else
+        cv::cvtColor(img, img, cv::COLOR_BGR2GRAY);
 #endif
     }
     img.convertTo(img, CV_32F, 1 / 255.f);

--- a/src/recttools.hpp
+++ b/src/recttools.hpp
@@ -130,7 +130,13 @@ inline cv::Mat subwindow(const cv::Mat &in, const cv::Rect & window, int borderT
 inline cv::Mat getGrayImage(cv::Mat img)
 {
     if (img.channels() == 3)
+    {
+#if(CV_MAJOR_VERSION == 4)
+        cv::cvtColor(img, img, cv::COLOR_BGR2GRAY);
+#else
         cv::cvtColor(img, img, CV_BGR2GRAY);
+#endif
+    }
     img.convertTo(img, CV_32F, 1 / 255.f);
     return img;
 }


### PR DESCRIPTION
A pull request to deal with the change from CV_BGR2GRAY to cv::COLOR_BGR2GRAY in OpenCV 4.